### PR TITLE
golang-http-80-xieweicarl2018 to v0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: golang-http-80-xieweicarl2018
+  repository: http://jenkins-x-chartmuseum:8080
+  version: v0.0.1
 - name: serverless-jenkins-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: v0.0.1


### PR DESCRIPTION
Promote golang-http-80-xieweicarl2018 to version v0.0.1