### PR TITLE
golang-http-81-xieweicarl2018 to v0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: v0.0.1
 - name: golang-http-81-xieweicarl2018
   repository: http://jenkins-x-chartmuseum:8080
-  version: v0.0.1
+  version: v0.0.2
 - name: serverless-jenkins-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: v0.0.1


### PR DESCRIPTION
Promote golang-http-81-xieweicarl2018 to version v0.0.2